### PR TITLE
fix: normalize ACPM folder path using path.resolve

### DIFF
--- a/src/cli/acpm.ts
+++ b/src/cli/acpm.ts
@@ -74,13 +74,23 @@ async function collectFolderPermissionsWithDeps(
       continue;
     }
 
+    const resolvedPath = path.resolve(folderPath);
+    const cwd = process.cwd();
+    if (!resolvedPath.startsWith(cwd + path.sep) && resolvedPath !== cwd) {
+      const proceed = await yesNo(
+        `"${resolvedPath}" is outside the project directory. Continue?`,
+        false
+      );
+      if (!proceed) continue;
+    }
+
     const accessChoice = await select(
-      `Select access level for ${folderPath}:`,
+      `Select access level for ${resolvedPath}:`,
       FOLDER_ACCESS_OPTIONS,
       1
     );
 
-    permissions.push({ path: path.posix.normalize(folderPath), access: accessChoice as FolderAccess });
+    permissions.push({ path: resolvedPath, access: accessChoice as FolderAccess });
 
     const addAnother = await yesNo('Add another folder permission?', false);
     if (!addAnother) {


### PR DESCRIPTION
Closes  #4

## 문제
CLI에서 경로 저장 시 `path.posix.normalize()`를 사용하고, 평가기에서는 `path.resolve()`를 사용해 정규화 방식이 달랐습니다. 또한 `../` 같은 입력을 막지 않아 프로젝트 외부 경로에 권한 규칙이 적용될 수 있었습니다.

## 수정
- `path.posix.normalize()` → `path.resolve()`로 변경해 평가기와 동일한 방식으로 절대경로 저장
- 프로젝트 외부 경로 입력 시 사용자에게 경고 후 확인